### PR TITLE
support for multiline css values

### DIFF
--- a/cssmin.c
+++ b/cssmin.c
@@ -166,9 +166,14 @@ machine(int c)
 				} else if (c == '}') {
 					//handle unterminated declaration
 					state = STATE_FREE;
-				} else if ( c == '\n' ) {
-					c = 0;
-					state = STATE_BLOCK;
+				} else if ( c == '\n') {
+				  //skip new lines
+				  c = 0;
+				} else if (c == ' ' ) {
+				  //skip multiple spaces after each other
+				  if( peek() == c ) {
+					  c = 0;
+					}
 				}
 				
 			} else if (c == ')') {

--- a/cssminunit.php
+++ b/cssminunit.php
@@ -64,6 +64,23 @@ test;
 
 //---------
 
+$test = 'multi-line declarations should not be lost';
+$tests[$test] = <<<test
+body {
+    line-height:1.5;
+    background: transparent
+        url(images/newwiz_back.gif.xhtml) repeat-x
+        0 0;
+   	font-family:"Trebuchet MS",Helvetica,sans-serif;
+}
+test;
+
+$results[$test] = <<<test
+body{line-height:1.5;background: transparent url(images/newwiz_back.gif.xhtml) repeat-x 0 0;font-family:"Trebuchet MS",Helvetica,sans-serif;}
+test;
+
+//---------
+
 
 $pass = 0;
 $fails = 0;


### PR DESCRIPTION
hey, thanks for this great and easy utility. It fits our needs quite well. However, I found a small glitch when the css contains declarations that are splitted into multiple lines.
I took the time to fix it and verified by adding a corresponding test. Would be great if you could integrate that fix.
