### PR TITLE
Handling @media queries that span multiple lines

### DIFF
--- a/cssmin.c
+++ b/cssmin.c
@@ -130,8 +130,11 @@ machine(int c)
 				@import etc.
 				@font-face{
 			*/
-			if (c == '\n' || c == ';') {
+			if ((c == '\n' && peek() == '\n') || c == ';') {
 				c = ';';
+				state = STATE_FREE;
+			} else if (c == '\n'){
+				c = ' ';
 				state = STATE_FREE;
 			} else if(c == '{') {
 				state = STATE_BLOCK;

--- a/cssminunit.php
+++ b/cssminunit.php
@@ -63,6 +63,22 @@ body{font-family:"Trebuchet MS",Helvetica,sans-serif}
 test;
 
 //---------
+$test = '@media queries can be spread across multiple lines';
+$tests[$test] = <<<test
+@media only screen
+and (min-device-width: 400px){
+	body {
+		background-color: red !important;
+	}
+}
+test;
+
+$results[$test] = <<<test
+@media only screen and (min-device-width: 400px){body { background-color: red !important;}}
+test;
+
+
+//---------
 
 $test = 'multi-line declarations should not be lost';
 $tests[$test] = <<<test


### PR DESCRIPTION
Hi Ryan,

I have the following CSS:

``` css
@media screen 
and (min-device-width: 400px){
    body {
        background-color: red !important;   
    }
}
```

`cssmin` turns it into this (I've re-added the newlines for clarity):

``` css
@media screen ;
and (min-device-width: 400px){
    body {
        background-color: red !important;   
    }
}
```

Notice the extra `;` character on the first line.

I'm not entirely sure that this fix won't cause other issues, but all of the tests pass. I've also added a test case specifically for this.

Is there a better way to do it?
